### PR TITLE
Add install script for *nix and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: push
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check all resources
+        id: gradle
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: check --scan
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+
+  publish:
+    needs: check
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish to GitHub Pages
+      id: gradle
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: publish --scan
+        wrapper-cache-enabled: true
+        dependencies-cache-enabled: true
+      env:
+        GITHUB_KEY: nokeedevbot
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,37 @@
+:jbake-type: page
+:jbake-status: published
+
+= Installation
 Use the following command to install Nokee on your system:
 
-NOTE: Please inspect https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.sh prior to running any of these scripts to ensure safety.
+IMPORTANT: Please inspect https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.sh and/or https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.ps1 prior to running any of these scripts to ensure safety.
 We already know it's safe, but you should verify the security and contents of *any* script from the internet you are not familiar with.
 All of these scripts download a remote shell script and execute it on your machine.
 We take security very seriously.
 
-For *nix system: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.sh)"`
+[[curl]]
+==== via curl
 
-For Windows system: Coming soon!
+.Install using curl
+[source,sh]
+----
+bash <(curl -fsSL https://nokee.dev/install.sh)
+----
 
+[[wget]]
+==== via wget
+
+.Install using wget
+[source,sh]
+----
+bash <(wget https://nokee.dev/install.sh -O -)
+----
+
+[[powershell]]
+==== via powershell
+
+.Install using powershell
+[source,powershell]
+----
+Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression (Invoke-Webrequest 'https://nokee.dev/install.ps1' -UseBasicParsing).Content
+----

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 = Installation
 Use the following command to install Nokee on your system:
 
-IMPORTANT: Please inspect https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.sh and/or https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.ps1 prior to running any of these scripts to ensure safety.
+IMPORTANT: Please inspect https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.sh and/or https://raw.githubusercontent.com/nokeedev/install.nokee.dev/main/install.ps1 before running any of these scripts to ensure safety.
 We already know it's safe, but you should verify the security and contents of *any* script from the internet you are not familiar with.
 All of these scripts download a remote shell script and execute it on your machine.
 We take security very seriously.
@@ -35,3 +35,16 @@ bash <(wget https://nokee.dev/install.sh -O -)
 ----
 Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression (Invoke-Webrequest 'https://nokee.dev/install.ps1' -UseBasicParsing).Content
 ----
+
+[[manually]]
+==== by hand
+
+The just of the install script above is to install the nokee.init.gradle script inside your Gradle's init.d directory of your current user.
+The script performs additional checks to a successful start with Nokee.
+To manually install Nokee's conveniences on your system, you have to...
+
+1. Download the nokee.init.gradle script available.
+2. Copy the script to the `~/.gradle/init.d` directory. Note that you may need to create this directory before copying the script.
+3. Profit!
+
+IMPORTANT: Please ensure you have a working link:https://gradle.org/install[installation of Gradle].

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,86 @@
+buildscript {
+    dependencies {
+        classpath 'dev.nokee.docs:site:latest.integration' // For adhoc task types
+    }
+    repositories {
+        jcenter()
+        maven { url = 'https://dl.bintray.com/nokeedev/documentations' }
+        maven { url = 'https://dl.bintray.com/nokeedev/distributions-snapshots' }
+    }
+}
+
+plugins {
+    id 'groovy'
+    id 'dev.nokee.documentation.github-pages-publish' version '0.2.5'
+}
+
+import dev.nokee.docs.publish.githubpages.tasks.PublishToGitHubPages
+import dev.nokee.docs.site.tasks.GenerateGitHubPagesCustomDomainCanonicalNameRecord
+import dev.nokee.docs.site.tasks.GenerateGitHubPagesNoJekyll
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+repositories {
+    jcenter()
+    maven { url = 'https://dl.bintray.com/nokeedev/distributions-snapshots' }
+}
+
+dependencies {
+    testImplementation 'dev.nokee:coreExec:0.5.0-198956b7'
+    testImplementation platform('org.spockframework:spock-bom:1.2-groovy-2.5')
+    testImplementation 'org.spockframework:spock-core'
+    testImplementation 'org.apache.commons:commons-lang3:latest.release'
+    testImplementation 'dev.gradleplugins:gradle-fixtures-file-system:latest.integration'
+    testImplementation 'org.asciidoctor:asciidoctorj-api:2.2.0'
+    testImplementation 'org.asciidoctor:asciidoctorj:2.2.0'
+}
+
+def expectedNokeeInitScript = layout.buildDirectory.file('nokee.init.gradle.expected')
+def fetchNokeeInitScriptTask = tasks.register('fetchExpectedNokeeInitScript') { task ->
+    task.outputs.file(expectedNokeeInitScript)
+    task.doLast {
+        expectedNokeeInitScript.get().asFile.text = project.resources.text.fromUri('https://raw.githubusercontent.com/nokeedev/init.nokee.dev/main/nokee.init.gradle').asString()
+    }
+}
+
+tasks.named('test', Test) { task ->
+    task.dependsOn(fetchNokeeInitScriptTask)
+
+    task.inputs.file('install.ps1')
+    task.inputs.file('install.sh')
+    task.inputs.file('README.adoc')
+    task.inputs.file(expectedNokeeInitScript)
+
+    task.systemProperty('dev.nokee.install.ps1', file('install.ps1'))
+    task.systemProperty('dev.nokee.install.sh', file('install.sh'))
+    task.systemProperty('dev.nokee.install.readme', file('README.adoc'))
+    task.systemProperty('dev.nokee.install.init', expectedNokeeInitScript.get().asFile)
+}
+
+// TODO: Publish README.adoc renamed/moved to install/index.adoc as jbake-content to be hosted as nokee.dev/install/
+// TODO: Render README.adoc to index.html (renamed to index.adoc) and include in site to be published on install.nokee.dev
+// TODO: Publish install.ps1 and install.sh as jbake-asset and consume under nokee.dev to host under nokee.dev/install.ps1 + nokee.dev/install.sh
+
+// GitHub Pages
+def customDomainTask = tasks.register('generateCustomDomainAlias', GenerateGitHubPagesCustomDomainCanonicalNameRecord) { task ->
+    task.getOutputFile().set(layout.buildDirectory.file('CNAME'))
+    task.getCustomDomain().set(task.subdomain('install.nokee.dev'))
+}
+
+def noJekyllTask = tasks.register('generateNoJekyll', GenerateGitHubPagesNoJekyll)
+
+def siteTask = tasks.register('site', Sync) { task ->
+    task.from(file('install.ps1'))
+    task.from(file('install.sh'))
+    task.from(customDomainTask.flatMap { it.outputFile })
+    task.from(noJekyllTask.flatMap { it.outputFile })
+    task.destinationDir = layout.buildDirectory.dir('site').get().asFile
+}
+
+tasks.named('publishToGitHubPages', PublishToGitHubPages) { task ->
+    task.publishDirectory.fileProvider(siteTask.map { it.destinationDir })
+    task.uri = uri('https://github.com/nokeedev/install.nokee.dev.git') // TODO: Should auto-detect to current repo
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,70 @@
+#!/usr/bin/env pwsh
+#Requires -version 5
+
+# Nokee installer
+# usage: (in powershell)
+#  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
+
+param (
+    [string]$version = "main",
+    [string]$installdir = ""
+)
+
+& {
+    $ErrorActionPreference = 'Stop'
+
+    function writeErrorTip($msg) {
+        Write-Host $msg -BackgroundColor Red -ForegroundColor White
+    }
+
+    if (-not $env:CI) {
+        $logo = @(
+            '                 _                               '
+            '     _ __   ___ | | _____  ___                   '
+            '    | ''_ \ / _ \| |/ / _ \/ _ \                 '
+            '    | | | | (_) |   <  __/  __/                  '
+            '    |_| |_|\___/|_|\_\___|\___| installer        '
+            '         Painless native development with Gradle '
+            '                                                 '
+            '   >  Manual: https://nokee.dev/getting-started  '
+            '                                                 ')
+        Write-Host $([string]::Join("`n", $logo)) -ForegroundColor Green
+    }
+
+    if ($IsLinux -or $IsMacOS) {
+        writeErrorTip 'Install on *nix is not supported, try '
+        writeErrorTip '(Use curl) "bash <(curl -fsSL https://nokee.dev/install.sh)"'
+        writeErrorTip 'or'
+        writeErrorTip '(Use wget) "bash <(wget https://nokee.dev/install.sh -O -)"'
+        throw 'Unsupported platform'
+    }
+
+    # $temppath = ($env:TMP, $env:TEMP, "$(Get-Location)" -ne $null)[0]
+    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+
+    if ($null -eq $installdir -or $installdir -match '^\s*$') {
+        $installdir = & {
+            if ($HOME) {
+                return Join-Path $HOME '.gradle\init.d'
+            }
+            return 'gradle'
+        }
+    }
+    $installdir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($installdir)
+
+    function nokeeInstall {
+        $outfile = Join-Path $installdir "nokee.init.gradle"
+		New-Item "$installdir" -ItemType Directory
+		$url = "https://raw.githubusercontent.com/nokeedev/init.nokee.dev/main/nokee.init.gradle"
+        Write-Host "Start downloading $url .."
+        try {
+            Invoke-Webrequest $url -OutFile $outfile -UseBasicParsing
+        } catch {
+            writeErrorTip 'Download failed!'
+            writeErrorTip 'Check your network'
+            throw
+        }
+    }
+
+    nokeeInstall
+}

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,10 @@
-#!/bin/bash
-set -u
+#!/usr/bin/env bash
+
+# nokee getter
+# usage: bash <(curl -s <my location>) [branch] [installdir]
+
+set -o pipefail
+#set -u
 
 # string formatters
 if [[ -t 1 ]]; then
@@ -22,6 +27,10 @@ shell_join() {
     printf " "
     printf "%s" "${arg// /\ }"
   done
+}
+
+logo() {
+  printf "${tty_blue}${tty_bold}%s${tty_reset}\n" "$1"
 }
 
 ohai() {
@@ -58,6 +67,16 @@ wait_for_user() {
   fi
 }
 
+logo ""
+logo "                 _                               "
+logo "     _ __   ___ | | _____  ___                   "
+logo "    | '_ \ / _ \| |/ / _ \/ _ \                  "
+logo "    | | | | (_) |   <  __/  __/                  "
+logo "    |_| |_|\___/|_|\_\___|\___| installer        "
+logo "         Painless native development with Gradle "
+logo "                                                 "
+logo "   👉  Manual: https://nokee.dev/getting-started "
+logo "                                                 "
 ohai "This script will install:"
 echo "${HOME}/.gradle/init.d/nokee.init.gradle"
 
@@ -74,7 +93,7 @@ if [[ "${#mkdirs[@]}" -gt 0 ]]; then
   printf "%s\n" "${mkdirs[@]}"
 fi
 
-if [[ -t 0 && -z "${CI-}" ]]; then
+if [[ -n "${NOKEE_TESTING+set}" || -t 0 && -z "${CI-}" ]]; then
   wait_for_user
 fi
 
@@ -84,7 +103,7 @@ fi
 
 ohai "Downloading and installing Nokee..."
 (
-  execute "curl" "-o" "${HOME}/.gradle/init.d/nokee.init.gradle" "https://raw.githubusercontent.com/nokeedev/init.nokee.dev/master/nokee.init.gradle"
+  execute "curl" "-o" "${HOME}/.gradle/init.d/nokee.init.gradle" "https://raw.githubusercontent.com/nokeedev/init.nokee.dev/main/nokee.init.gradle"
 ) || exit 1
 
 ohai "Installation successful!"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = 'https://dl.bintray.com/nokeedev/documentations' }
+        maven { url = 'https://dl.bintray.com/nokeedev/distributions-snapshots' }
+    }
+}
+
 rootProject.name = 'install.nokee.dev'
+
+if (file('../toolbox').exists()) {
+    includeBuild '../toolbox'
+}

--- a/src/test/groovy/dev/nokee/install/AbstractInstallScriptIntegrationTest.groovy
+++ b/src/test/groovy/dev/nokee/install/AbstractInstallScriptIntegrationTest.groovy
@@ -1,0 +1,126 @@
+package dev.nokee.install
+
+import dev.gradleplugins.fixtures.file.FileSystemUtils
+import org.apache.commons.lang3.SystemUtils
+import org.hamcrest.CoreMatchers
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.util.regex.Pattern
+
+import static org.hamcrest.MatcherAssert.assertThat
+
+abstract class AbstractInstallScriptIntegrationTest extends Specification implements InstallScriptFixture {
+    @Rule
+    TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def "can install init script in the user home directory"() {
+        def outStream = new ByteArrayOutputStream()
+        def process = [installScriptUnderTest].execute(["HOME=${temporaryFolder.root}"], null)
+        def outStreamThread = process.consumeProcessOutputStream(outStream)
+        process.out << "\n"
+        expect:
+        process.waitFor() == 0
+        assertInstallationSucceeded(temporaryFolder.root)
+        String expectedOutput = """==> This script will install:
+${temporaryFolder.root}/.gradle/init.d/nokee.init.gradle
+==> The following new directories will be created:
+${temporaryFolder.root}/.gradle/init.d
+==> Downloading and installing Nokee...
+==> Installation successful!"""
+        assertThat(normalize(outStream.toString()), CoreMatchers.endsWith(expectedOutput))
+
+        cleanup:
+        outStreamThread?.join()
+    }
+
+    def "shows the logo"() {
+        def outStream = new ByteArrayOutputStream()
+        def process = [installScriptUnderTest].execute(["HOME=${temporaryFolder.root}", 'NOKEE_TESTING='], null)
+        def outStreamThread = process.consumeProcessOutputStream(outStream)
+        process.out << "\n"
+        expect:
+        process.waitFor() == 0
+        normalize(outStream.toString()).startsWith(nokeeConsoleLogo)
+
+        cleanup:
+        outStreamThread?.join()
+    }
+
+    // Test it shows what will be done and wait for user input
+
+    // Test it shows what is done (with the various header)
+
+    def "cancels the installation for any inputs other than ENTER"() {
+        def outStream = new ByteArrayOutputStream()
+        def process = [installScriptUnderTest].execute(["HOME=${temporaryFolder.root}", 'NOKEE_TESTING='], null)
+        def outStreamThread = process.consumeProcessOutputStream(outStream)
+        process.out << "a"
+        expect:
+        process.waitFor() == 1
+        FileSystemUtils.getDescendants(temporaryFolder.root) == [] as Set
+        normalize(outStream.toString()).contains """==> This script will install:
+${temporaryFolder.root}/.gradle/init.d/nokee.init.gradle
+"""
+        !outStream.toString().contains('==> Installation successful!')
+
+        cleanup:
+        outStreamThread?.join()
+    }
+    // Test proper error message when no curl or wget
+    // Test proper error message when no HOME variable
+
+    // Test URL from README exists in proper location
+    // Test command from README
+
+    def "contains valid urls"() {
+        def urls = extractAllUrlsFromScript(installScriptUnderTest)
+
+        expect:
+        urls == expectedUrlsContainedInScript
+        urls.collect { AbstractInstallScriptIntegrationTest.head(it) }.every()
+    }
+
+    private static String normalize(String s) {
+        return s.replace('\r\n', '\n').trim()
+    }
+
+    // Crappy way to issue an head request
+    private static boolean head(URL url) {
+        HttpURLConnection httpConnection = null
+        System.setProperty("http.keepAlive", "false")
+        try {
+            httpConnection = (HttpURLConnection) url.openConnection()
+            httpConnection.setRequestMethod("HEAD")
+            httpConnection.getInputStream().close()
+            return httpConnection.responseCode == 200
+        } finally {
+            httpConnection?.disconnect()
+        }
+    }
+
+    protected abstract File getInstallScriptUnderTest()
+
+    protected abstract Set<URL> getExpectedUrlsContainedInScript()
+
+    private static Set<URL> extractAllUrlsFromScript(File script) {
+        def regex = Pattern.compile('https?://(www\\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\\.[a-zA-Z0-9]{1,6}\\b([-a-zA-Z0-9@:%_+.~#?&/=]*)')
+        def matcher = regex.matcher(script.text)
+        def result = [] as Set
+        while (matcher.find()) {
+            result.add(new URL(matcher.group(0)))
+        }
+        return result
+    }
+
+    private static String getExpectedInitScriptContent() {
+        return SystemProperties.getInstallExpectedInitScript().text
+    }
+
+    protected abstract getNokeeConsoleLogo()
+}
+
+// Publish *.text script as jbake-assets
+// Publish install.sh, install.ps1, and README.adoc in GitHub pages
+// Publish README or whatever content as jbake-content

--- a/src/test/groovy/dev/nokee/install/InstallBashScriptIntegrationTest.groovy
+++ b/src/test/groovy/dev/nokee/install/InstallBashScriptIntegrationTest.groovy
@@ -1,0 +1,32 @@
+package dev.nokee.install
+
+import org.apache.commons.lang3.SystemUtils
+import spock.lang.Requires
+
+@Requires({ !SystemUtils.IS_OS_WINDOWS })
+class InstallBashScriptIntegrationTest extends AbstractInstallScriptIntegrationTest {
+    @Override
+    protected File getInstallScriptUnderTest() {
+        return SystemProperties.installBashScript
+    }
+
+    @Override
+    protected Set<URL> getExpectedUrlsContainedInScript() {
+        return [new URL('https://nokee.dev/getting-started'), new URL('https://raw.githubusercontent.com/nokeedev/init.nokee.dev/main/nokee.init.gradle')] as Set
+    }
+
+    @Override
+    protected getNokeeConsoleLogo() {
+        return """
+                 _                               
+     _ __   ___ | | _____  ___                   
+    | '_ \\ / _ \\| |/ / _ \\/ _ \\                  
+    | | | | (_) |   <  __/  __/                  
+    |_| |_|\\___/|_|\\_\\___|\\___| installer        
+         Painless native development with Gradle 
+                                                 
+   👉  Manual: https://nokee.dev/getting-started 
+""".trim() // so we have a nice display above ;)
+    }
+
+}

--- a/src/test/groovy/dev/nokee/install/InstallPowershellScriptIntegrationTest.groovy
+++ b/src/test/groovy/dev/nokee/install/InstallPowershellScriptIntegrationTest.groovy
@@ -1,0 +1,31 @@
+package dev.nokee.install
+
+import org.apache.commons.lang3.SystemUtils
+import spock.lang.Requires
+
+@Requires({ SystemUtils.IS_OS_WINDOWS })
+class InstallPowershellScriptIntegrationTest extends AbstractInstallScriptIntegrationTest {
+    @Override
+    protected File getInstallScriptUnderTest() {
+        return SystemProperties.installPowershellScript
+    }
+
+    @Override
+    protected Set<URL> getExpectedUrlsContainedInScript() {
+        return [new URL('https://nokee.dev/getting-started'), new URL('https://nokee.dev/install.sh'), new URL('https://raw.githubusercontent.com/nokeedev/init.nokee.dev/main/nokee.init.gradle')] as Set
+    }
+
+    @Override
+    protected String getNokeeConsoleLogo() {
+        return """
+                 _                               
+     _ __   ___ | | _____  ___                   
+    | '_ \\ / _ \\| |/ / _ \\/ _ \\                  
+    | | | | (_) |   <  __/  __/                  
+    |_| |_|\\___/|_|\\_\\___|\\___| installer        
+         Painless native development with Gradle 
+                                                 
+   >  Manual: https://nokee.dev/getting-started 
+""".trim() // so we have a nice display above ;)
+    }
+}

--- a/src/test/groovy/dev/nokee/install/InstallScriptFixture.groovy
+++ b/src/test/groovy/dev/nokee/install/InstallScriptFixture.groovy
@@ -1,0 +1,11 @@
+package dev.nokee.install
+
+import static dev.gradleplugins.fixtures.file.FileSystemUtils.file
+import static dev.gradleplugins.fixtures.file.FileSystemUtils.getDescendants
+
+trait InstallScriptFixture {
+    void assertInstallationSucceeded(File userHomeDirectory) {
+        assert getDescendants(userHomeDirectory) == ['.gradle/init.d/nokee.init.gradle'] as Set
+        assert file(userHomeDirectory, '.gradle/init.d/nokee.init.gradle').text == SystemProperties.installExpectedInitScript.text
+    }
+}

--- a/src/test/groovy/dev/nokee/install/ReadmeDocumentationTest.groovy
+++ b/src/test/groovy/dev/nokee/install/ReadmeDocumentationTest.groovy
@@ -1,0 +1,127 @@
+package dev.nokee.install
+
+import org.apache.commons.lang3.SystemUtils
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.StructuralNode
+import org.asciidoctor.jruby.ast.impl.ListImpl
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Files
+
+import static org.asciidoctor.OptionsBuilder.options
+import static org.junit.Assume.assumeFalse
+import static org.junit.Assume.assumeTrue
+
+class ReadmeDocumentationTest extends Specification implements InstallScriptFixture {
+    @Shared Asciidoctor asciidoctor = Asciidoctor.Factory.create()
+    @Shared Document readme = asciidoctor.loadFile(readmeFile, options().asMap())
+
+    private static File getReadmeFile() {
+        return SystemProperties.installReadMe
+    }
+
+    // TODO: Extract HtmlLinkTester to docs-gradle-plugins
+//    def "checks for broken links"() {
+//        given:
+//        def rootDirectory = Files.createTempDirectory('nokee')
+//        def renderedReadMeFile = rootDirectory.resolve('readme.html').toFile()
+//        renderedReadMeFile.text = asciidoctor.convertFile(readmeFile, options().toFile(false))
+//
+//        expect:
+//        def report = new HtmlLinkTester(validEmails("hello@nokee.dev"), new HtmlLinkTester.BlackList() {
+//            @Override
+//            boolean isBlackListed(URI uri) {
+//                if (uri.scheme == 'file') {
+//                    def path = rootDirectory.toUri().relativize(uri).toString()
+//                    if (new File(readmeFile.parentFile, path).exists()) {
+//                        return true
+//                    }
+//                }
+//                return false
+//            }
+//        }).reportBrokenLinks(rootDirectory.toFile())
+//        report.assertNoFailures()
+//    }
+
+    @Unroll
+    def "check '#sample.title' code snippet"(sample) {
+        given:
+        assumeFalse('wget requires a mocked http server', sample.command.contains('wget'))
+        assumeTrue((sample.requiredShell == Shell.BASH && !SystemUtils.IS_OS_WINDOWS) || (sample.requiredShell == Shell.POWERSHELL && SystemUtils.IS_OS_WINDOWS))
+        def userHomeDirectory = Files.createTempDirectory('install.nokee.dev')
+
+        when:
+        def process = sample.commandUnderTest.execute(["HOME=${userHomeDirectory}"], null)
+
+        then:
+        process.waitFor() == 0
+        assertInstallationSucceeded(userHomeDirectory.toFile())
+
+        where:
+        sample << sampleBlocks
+    }
+
+    static class Sample {
+        final String title
+        final String command
+        final Shell requiredShell
+
+        Sample(String title, String command, Shell requiredShell) {
+            this.title = title
+            this.command = command
+            this.requiredShell = requiredShell
+        }
+
+        List<String> getCommandUnderTest() {
+            return requiredShell.launcherCommand + [command]
+        }
+    }
+
+    static enum Shell {
+        BASH(['bash', '-c']), POWERSHELL([])
+
+        final launcherCommand
+        private Shell(List<String> launcherCommand) {
+            this.launcherCommand = launcherCommand
+        }
+    }
+
+    List<Sample> getSampleBlocks() {
+        return findSnippetBlocks().collect {
+            // Unexpand the less-than character
+            def command = it.content.toString().replace('&lt;', '<')
+
+            // TODO: Create smoke test to ensure everything is proper.
+            //    My current thought is to "release" smoke-test jar that can then be run at various publishing gate to ensure everything is working as expected.
+            // Use local install script instead
+            command = command.replace('https://nokee.dev/install.sh', SystemProperties.installBashScript.toURI().toString()).replace('https://nokee.dev/install.ps1', SystemProperties.installPowershellScript.toURI().toString())
+            def requiredShell = command.contains('bash') ? Shell.BASH : Shell.POWERSHELL
+            return new Sample(it.title, command, requiredShell)
+        }
+    }
+
+    List<StructuralNode> findSnippetBlocks() {
+        def snippets = new ArrayList<StructuralNode>();
+        def queue = new ArrayDeque<StructuralNode>();
+        queue.add(readme);
+        while (!queue.isEmpty()) {
+            StructuralNode node = queue.poll();
+            if (node instanceof ListImpl) {
+                queue.addAll(((ListImpl) node).getItems());
+            } else {
+                for (StructuralNode child : node.getBlocks()) {
+                    if (child.isBlock() && child.getContext().equals("listing") && child.getStyle().equals("source")) {
+                        snippets.add(child)
+                    } else {
+                        queue.offer(child);
+                    }
+                }
+            }
+        }
+
+        return snippets
+    }
+}

--- a/src/test/groovy/dev/nokee/install/SystemProperties.groovy
+++ b/src/test/groovy/dev/nokee/install/SystemProperties.groovy
@@ -1,0 +1,24 @@
+package dev.nokee.install
+
+class SystemProperties {
+    static File getInstallPowershellScript() {
+        return new File(get('dev.nokee.install.ps1'))
+    }
+
+    static File getInstallBashScript() {
+        return new File(get('dev.nokee.install.sh'))
+    }
+
+    static File getInstallReadMe() {
+        return new File(get('dev.nokee.install.readme'))
+    }
+
+    static File getInstallExpectedInitScript() {
+        return new File(get('dev.nokee.install.init'))
+    }
+
+    private static String get(String key) {
+        assert System.getProperties().containsKey(key)
+        return System.getProperty(key)
+    }
+}


### PR DESCRIPTION
These install scripts are for copying the nokee.init.gradle script to a user's global init.d folder on their system. This will be the preferred way of going forward for a couple of reason:
1- It allows for tighter integration in Gradle as we will be loaded in every Gradle process executed on the machine.
2- It allows to performs some "java" checks that native users may not be used.
3- It allows to install a working copy of Java to get native user started faster.
4- It allows to install a working copy of Gradle to get native user started faster.
5- It cuts down on the initial Gradle learning experience by having something working right away which we can verify through the install script